### PR TITLE
Fix warning caused by css file import

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1,6 +1,6 @@
 // @flow
-import stylesFlagIcon from 'flag-icon-css/css/flag-icon.css'
-import stylesMain from './styles/main.css'
+import * as stylesFlagIcon from 'flag-icon-css/css/flag-icon.css'
+import * as stylesMain from './styles/main.css'
 import type { CssModuleType } from './types/flow'
 
 const finalStyles: CssModuleType = {


### PR DESCRIPTION
In my project i use react-flag-icon-css library. And building app throw warnings:
![Zaznaczenie_316](https://user-images.githubusercontent.com/16646714/127880548-8954c647-4ce5-4b24-b775-940bdbac5c31.png)

I noticed, that adding `* as ` in import statements suppress this warnings.


